### PR TITLE
Update to Qt6 / Mod Organizer 2.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,47 @@
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# CMake
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+cmake-build*/
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,30 @@
 cmake_minimum_required(VERSION 3.16)
 
-project(preview_nif)
-set(project_type plugin)
-set(enable_warnings OFF)
+set(DEPENDENCIES_DIR C:/Repositories/bethesda/mo2/build/build)
+
+set(BOOST_ROOT ${DEPENDENCIES_DIR}/boost_1_83_0)
+set(QT_ROOT C:/Programs/Qt/6.5.2/msvc2019_64)
+set(FMT_ROOT ${DEPENDENCIES_DIR}/fmt-8.1.1)
+set(PYTHON_ROOT ${DEPENDENCIES_DIR}/python-3.11.5)
+set(CMAKE_INSTALL_PREFIX C:/Repositories/bethesda/mo2/build/install)
+set(LOOT_PATH ${DEPENDENCIES_DIR}/libloot-0.22.0-win64)
+set(SPDLOG_ROOT ${DEPENDENCIES_DIR}/spdlog-v1.10.0)
+set(LIBBSARCH_ROOT ${DEPENDENCIES_DIR}/libbsarch-0.0.9-release-x64)
+set(ZLIB_ROOT ${DEPENDENCIES_DIR}/zlib-v1.3)
+set(LZ4_ROOT ${DEPENDENCIES_DIR}/lz4-v1.9.4)
+set(SEVENZ_ROOT ${DEPENDENCIES_DIR}/7zip-23.01)
 
 if(DEFINED DEPENDENCIES_DIR)
-	include(${DEPENDENCIES_DIR}/modorganizer_super/cmake_common/project.cmake)
+	include(${DEPENDENCIES_DIR}/modorganizer_super/cmake_common/mo2.cmake)
 else()
-	include(../cmake_common/project.cmake)
+	include(${CMAKE_CURRENT_LIST_DIR}/cmake_common/mo2.cmake)
 endif()
+
+project(preview_nif)
+
 add_subdirectory(src)
 set(GLI_TEST_ENABLE OFF CACHE BOOL "Build gli unit tests")
 add_subdirectory(external/gli)
 add_subdirectory(external/nifly)
-target_link_libraries(${PROJECT_NAME} nifly gli)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE nifly gli)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # modorganizer-preview_nif
-NIF preview plugin for Mod Organizer
+NIF preview plugin for Mod Organizer 2
+
+For Qt6 builds of MO2 (version 2.5+)
+
+## How to build
+Follow the instructions at https://github.com/modorganizer2/mob. Then, open `CMakeLists.txt` and edit the variables at the top to the correct paths. Finally, build with cmake:
+
+```shell
+mkdir build
+cmake -S . -B build
+cmake --build build --config Release
+cmake --install build --config Release
+```

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,11 @@
 cmake_minimum_required(VERSION 3.16)
-if(DEFINED DEPENDENCIES_DIR)
-	include(${DEPENDENCIES_DIR}/modorganizer_super/cmake_common/src.cmake)
-else()
-	include(../../cmake_common/src.cmake)
-endif()
-requires_library(libbsarch)
-requires_project(game_features)
+
+add_library(preview_nif SHARED)
+mo2_configure_plugin(
+	preview_nif
+	WARNINGS OFF
+	PRIVATE_DEPENDS
+		libbsarch
+		Qt::OpenGLWidgets
+)
+mo2_install_target(preview_nif)

--- a/src/NifWidget.cpp
+++ b/src/NifWidget.cpp
@@ -2,9 +2,9 @@
 #include "NifExtensions.h"
 
 #include <QMouseEvent>
-#include <QWheelEvent>
 #include <QOpenGLContext>
 #include <QOpenGLFunctions_2_1>
+#include <QOpenGLVersionFunctionsFactory>
 using OpenGLFunctions = QOpenGLFunctions_2_1;
 
 NifWidget::NifWidget(
@@ -131,7 +131,7 @@ void NifWidget::initializeGL()
             update();
         });
 
-    auto f = QOpenGLContext::currentContext()->versionFunctions<OpenGLFunctions>();
+    auto f = QOpenGLVersionFunctionsFactory::get<OpenGLFunctions>(QOpenGLContext::currentContext());
 
     f->glEnable(GL_DEPTH_TEST);
     f->glDepthFunc(GL_LEQUAL);
@@ -140,7 +140,7 @@ void NifWidget::initializeGL()
 
 void NifWidget::paintGL()
 {
-    auto f = QOpenGLContext::currentContext()->versionFunctions<OpenGLFunctions>();
+    auto f = QOpenGLVersionFunctionsFactory::get<OpenGLFunctions>(QOpenGLContext::currentContext());
     f->glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
     for (auto& shape : m_GLShapes) {

--- a/src/OpenGLShape.cpp
+++ b/src/OpenGLShape.cpp
@@ -3,6 +3,7 @@
 
 #include <QOpenGLContext>
 #include <QOpenGLFunctions_2_1>
+#include <QOpenGLVersionFunctionsFactory>
 
 template <typename T>
 inline static QOpenGLBuffer* makeVertexBuffer(const std::vector<T>* data, GLuint attrib)
@@ -14,8 +15,7 @@ inline static QOpenGLBuffer* makeVertexBuffer(const std::vector<T>* data, GLuint
         if (buffer->create() && buffer->bind()) {
             buffer->allocate(data->data(), data->size() * sizeof(T));
 
-            auto f = QOpenGLContext::currentContext()
-                ->versionFunctions<QOpenGLFunctions_2_1>();
+            auto f = QOpenGLVersionFunctionsFactory::get<QOpenGLFunctions_2_1>(QOpenGLContext::currentContext());
 
             f->glEnableVertexAttribArray(attrib);
 
@@ -39,7 +39,7 @@ OpenGLShape::OpenGLShape(
     nifly::NiShape* niShape,
     TextureManager* textureManager)
 {
-    auto f = QOpenGLContext::currentContext()->versionFunctions<QOpenGLFunctions_2_1>();
+    auto f = QOpenGLVersionFunctionsFactory::get<QOpenGLFunctions_2_1>(QOpenGLContext::currentContext());
 
     auto shader = nifFile->GetShader(niShape);
     auto& version = nifFile->GetHeader().GetVersion();
@@ -327,7 +327,7 @@ void OpenGLShape::setupShaders(QOpenGLShaderProgram* program)
         program->setUniformValue("outerReflection", outerReflection);
     }
 
-    auto f = QOpenGLContext::currentContext()->versionFunctions<QOpenGLFunctions_2_1>();
+    auto f = QOpenGLVersionFunctionsFactory::get<QOpenGLFunctions_2_1>(QOpenGLContext::currentContext());
 
     for (std::size_t i = 0; i < ATTRIB_COUNT; i++) {
         if (vertexBuffers[i]) {

--- a/src/PreviewNif.cpp
+++ b/src/PreviewNif.cpp
@@ -30,7 +30,7 @@ QString PreviewNif::description() const
 
 MOBase::VersionInfo PreviewNif::version() const
 {
-    return MOBase::VersionInfo(0, 1, 8, 1, MOBase::VersionInfo::RELEASE_BETA);
+    return MOBase::VersionInfo(0, 2, 0, 0, MOBase::VersionInfo::RELEASE_BETA);
 }
 
 QList<MOBase::PluginSetting> PreviewNif::settings() const

--- a/src/TextureManager.cpp
+++ b/src/TextureManager.cpp
@@ -4,11 +4,11 @@
 #include <iplugingame.h>
 #include <dataarchives.h>
 
-#include <gli/gli.hpp>
 #include <libbsarch.h>
 
 #include <QOpenGLContext>
 #include <QOpenGLFunctions_2_1>
+#include <QOpenGLVersionFunctionsFactory>
 #include <QVector4D>
 
 #include <memory>
@@ -181,7 +181,7 @@ QOpenGLTexture* TextureManager::makeTexture(const gli::texture& texture)
     const gli::gl::format format = GL.translate(texture.format(), texture.swizzles());
     GLenum target = GL.translate(texture.target());
 
-    auto f = QOpenGLContext::currentContext()->versionFunctions<QOpenGLFunctions_2_1>();
+    auto f = QOpenGLVersionFunctionsFactory::get<QOpenGLFunctions_2_1>(QOpenGLContext::currentContext());
     QOpenGLTexture* glTexture = new QOpenGLTexture(static_cast<QOpenGLTexture::Target>(target));
 
     glTexture->create();

--- a/src/preview_nif_en.ts
+++ b/src/preview_nif_en.ts
@@ -4,6 +4,7 @@
 <context>
     <name>NifWidget</name>
     <message>
+        <location filename="NifWidget.cpp" line="91"/>
         <source>OpenGL debug message: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11,10 +12,12 @@
 <context>
     <name>PreviewNif</name>
     <message>
+        <location filename="PreviewNif.cpp" line="57"/>
         <source>Failed to load file: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="PreviewNif.cpp" line="87"/>
         <source>Verts: %1 | Faces: %2 | Shapes: %3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -22,6 +25,7 @@
 <context>
     <name>QObject</name>
     <message>
+        <location filename="TextureManager.cpp" line="117"/>
         <source>Failed to interface with managed game plugin</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
MO 2.5 updates Qt 5 to Qt 6, which breaks this plugin. I've updated this plugin to support Qt6, which basically involved fixing one breaking change regarding `QOpenGLContext::currentContext()->versionFunctions`.

The remaining changes are to make the build work with MO 2.5. I don't like that I had to hard-code library paths in CMake; if anyone knows of a more elegant way to resolve dependencies with MO2's build tools, please share!